### PR TITLE
Add `name` function

### DIFF
--- a/ColorKit/ColorKit.xcodeproj/project.pbxproj
+++ b/ColorKit/ColorKit.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		A10C0C83249E18BB00A321A5 /* CMYK.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10C0C82249E18BB00A321A5 /* CMYK.swift */; };
 		A10C0C85249E1AA700A321A5 /* CMYKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10C0C84249E1AA700A321A5 /* CMYKTests.swift */; };
+		A121A8A72581717B0005B702 /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = A121A8A62581717B0005B702 /* Name.swift */; };
+		A121A8AD258177FD0005B702 /* NameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A121A8AC258177FD0005B702 /* NameTests.swift */; };
 		A140DC2824C251F900CD8AA7 /* ColorDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A140DC2724C251F900CD8AA7 /* ColorDetailViewController.swift */; };
 		A14F98622422776A001E727C /* ComplementaryColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F98612422776A001E727C /* ComplementaryColor.swift */; };
 		A14F9864242277D7001E727C /* ComplementaryColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F9863242277D7001E727C /* ComplementaryColorTests.swift */; };
@@ -98,6 +100,8 @@
 /* Begin PBXFileReference section */
 		A10C0C82249E18BB00A321A5 /* CMYK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMYK.swift; sourceTree = "<group>"; };
 		A10C0C84249E1AA700A321A5 /* CMYKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMYKTests.swift; sourceTree = "<group>"; };
+		A121A8A62581717B0005B702 /* Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
+		A121A8AC258177FD0005B702 /* NameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameTests.swift; sourceTree = "<group>"; };
 		A140DC2724C251F900CD8AA7 /* ColorDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDetailViewController.swift; sourceTree = "<group>"; };
 		A14F98612422776A001E727C /* ComplementaryColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplementaryColor.swift; sourceTree = "<group>"; };
 		A14F9863242277D7001E727C /* ComplementaryColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplementaryColorTests.swift; sourceTree = "<group>"; };
@@ -218,6 +222,7 @@
 				A181C8962406D7A90008D4B7 /* Lab.swift */,
 				A181C89A2407F5340008D4B7 /* Hex.swift */,
 				A1FDCB7A2461F16400741DD6 /* Random.swift */,
+				A121A8A62581717B0005B702 /* Name.swift */,
 				A1BC6934241C328400E53FB9 /* RelativeLuminance.swift */,
 				A1BC6938241C372600E53FB9 /* ContrastRatio.swift */,
 				A14F98612422776A001E727C /* ComplementaryColor.swift */,
@@ -242,6 +247,7 @@
 				A1BC6936241C335B00E53FB9 /* RelativeLuminanceTests.swift */,
 				A1BC693A241C39D600E53FB9 /* ContrastRatioTests.swift */,
 				A14F9863242277D7001E727C /* ComplementaryColorTests.swift */,
+				A121A8AC258177FD0005B702 /* NameTests.swift */,
 				A1C4509F246EC5BE001EC796 /* AverageColorTests.swift */,
 				A16BA21E2473E6DE00E4E826 /* DominantColorsTests.swift */,
 				A192B20A248260BC005BC955 /* DominantColorQualityTests.swift */,
@@ -468,6 +474,7 @@
 				A1FDCB7B2461F16400741DD6 /* Random.swift in Sources */,
 				A181C87C240480620008D4B7 /* XYZ.swift in Sources */,
 				A10C0C83249E18BB00A321A5 /* CMYK.swift in Sources */,
+				A121A8A72581717B0005B702 /* Name.swift in Sources */,
 				A1A0978724B324B3009BAB08 /* ColorPalette.swift in Sources */,
 				A14F98622422776A001E727C /* ComplementaryColor.swift in Sources */,
 				A1BC6939241C372600E53FB9 /* ContrastRatio.swift in Sources */,
@@ -498,6 +505,7 @@
 				A181C87A2404796F0008D4B7 /* ComparisonTests.swift in Sources */,
 				A181C8952406D4890008D4B7 /* CGFloatExtensionsTests.swift in Sources */,
 				A181C878240477AD0008D4B7 /* RGBTests.swift in Sources */,
+				A121A8AD258177FD0005B702 /* NameTests.swift in Sources */,
 				A1A0978924B327CA009BAB08 /* PaletteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ColorKit/ColorKit/Name.swift
+++ b/ColorKit/ColorKit/Name.swift
@@ -1,0 +1,74 @@
+//
+//  Name.swift
+//  ColorKit
+//
+//  Created by Boris Emorine on 12/9/20.
+//  Copyright © 2020 BorisEmorine. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    /// This function gives a readable name (in English) to the current `UIColor` instance.
+    /// - Returns: The name of the color.
+    public func name() -> String {
+        let colorList = NamedColorList.BasicColors
+        var closestColor: (UIColor, String)?
+        var bestMatch: UIColor.ColorDifferenceResult = .init(value: CGFloat.infinity)
+        
+        for color in colorList {
+            let difference = self.difference(from: color.0, using: .CIE94)
+            
+            if difference < bestMatch {
+                closestColor = color
+                bestMatch = difference
+            }
+        }
+        
+        return closestColor!.1
+    }
+    
+}
+
+/// Adds the content of two dictionaries together.
+private func +=<UIColor, String> (lhs: [UIColor: String], rhs: [UIColor: String]) -> [UIColor: String] {
+    let summedUpDictionay = lhs.reduce(into: rhs) { (result, colorNamePair) in
+        result[colorNamePair.key] = colorNamePair.value
+    }
+    return summedUpDictionay
+}
+
+/// A collection of lists of colors and their names.
+struct NamedColorList {
+    
+    static let BasicColors = AdditivePrimaryColors += AdditiveSecondaryColors += AdditiveTertiaryColors += GrayShadeColors
+    
+    static let AdditivePrimaryColors = [
+        UIColor(red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0): "red",
+        UIColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0): "green",
+        UIColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0): "blue"
+    ]
+    
+    static let AdditiveSecondaryColors = [
+        UIColor(red: 1.0, green: 1.0, blue: 0.0, alpha: 1.0): "yellow",
+        UIColor(red: 1.0, green: 0.0, blue: 1.0, alpha: 1.0): "magenta",
+        UIColor(red: 0.0, green: 1.0, blue: 1.0, alpha: 1.0): "cyan"
+    ]
+    
+    static let AdditiveTertiaryColors = [
+        UIColor(red: 0.0, green: 0.5, blue: 1.0, alpha: 1.0): "azure",
+        UIColor(red: 0.5, green: 0.0, blue: 1.0, alpha: 1.0): "violet",
+        UIColor(red: 1.0, green: 0.0, blue: 0.5, alpha: 1.0): "rose",
+        UIColor(red: 1.0, green: 0.5, blue: 0.0, alpha: 1.0): "orange",
+        UIColor(red: 0.5, green: 1.0, blue: 0.0, alpha: 1.0): "chartreuse",
+        UIColor(red: 0.0, green: 1.0, blue: 0.5, alpha: 1.0): "spring green"
+    ]
+    
+    static let GrayShadeColors = [
+        UIColor.black: "black",
+        UIColor.white: "white",
+        UIColor.gray: "gray"
+    ]
+    
+}

--- a/ColorKit/ColorKitTests/NameTests.swift
+++ b/ColorKit/ColorKitTests/NameTests.swift
@@ -1,0 +1,64 @@
+//
+//  NameTests.swift
+//  ColorKitTests
+//
+//  Created by Boris Emorine on 12/9/20.
+//  Copyright © 2020 BorisEmorine. All rights reserved.
+//
+
+import XCTest
+import ColorKit
+
+class NameTests: XCTestCase {
+
+    func testPrimaryExact() {
+        let color = UIColor.blue
+        XCTAssertEqual(color.name(), "blue")
+    }
+    
+    func testSecondaryExact() {
+        let color = UIColor.purple
+        XCTAssertEqual(color.name(), "violet")
+    }
+    
+    func testTertiaryExact() {
+        let color = UIColor(red: 0.5, green: 1.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual(color.name(), "chartreuse")
+    }
+    
+    func testClose() {
+        let color = UIColor(red: 0.9, green: 0.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual(color.name(), "red")
+    }
+    
+    func testBlack() {
+        let color = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual(color.name(), "black")
+    }
+    
+    func testWhite() {
+        let color = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+        XCTAssertEqual(color.name(), "white")
+    }
+    
+    func testGray() {
+        let color = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
+        XCTAssertEqual(color.name(), "gray")
+    }
+    
+    func testDarkGray() {
+        let color = UIColor(red: 0.3, green: 0.3, blue: 0.3, alpha: 1.0)
+        XCTAssertEqual(color.name(), "gray")
+    }
+    
+    func testLightGray() {
+        let color = UIColor(red: 0.7, green: 0.7, blue: 0.7, alpha: 1.0)
+        XCTAssertEqual(color.name(), "gray")
+    }
+    
+    func testRandom() {
+        let color = UIColor.random()
+        XCTAssertNotNil(color.name())
+    }
+    
+}


### PR DESCRIPTION
This commit simply adds a new function `name()` to `UIColor` instances via an extension.
This function is useful to get a readable english name of the current color.

Fixes #6.