### PR TITLE
Bugfix in hex string color decoding

### DIFF
--- a/ColorKit/ColorKit/Hex.swift
+++ b/ColorKit/ColorKit/Hex.swift
@@ -27,7 +27,7 @@ extension UIColor {
         case 6: // 0xRRGGBB
             (a, r, g, b) = (255, hexValue >> 16, hexValue >> 8 & 0xFF, hexValue & 0xFF)
         case 8: // 0xRRGGBBAA
-            (a, r, g, b) = (hexValue >> 24, hexValue >> 16 & 0xFF, hexValue >> 8 & 0xFF, hexValue & 0xFF)
+            (r, g, b, a) = (hexValue >> 24, hexValue >> 16 & 0xFF, hexValue >> 8 & 0xFF, hexValue & 0xFF)
         default:
             (a, r, g, b) = (255, 0, 0, 0)
         }


### PR DESCRIPTION
This PR fixes a bug in the hex string UIColor decoding.

In the case of a `RRGGBBAA` string, the red component was being decoded as the alpha component.